### PR TITLE
 Fix empty unit spinners

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -49,6 +49,7 @@ class ConvertActivity(activity.Activity):
         cell = Gtk.CellRendererText()
         self.combo1.pack_start(cell, True)
         self.combo1.add_attribute(cell, 'markup', 0)
+        self.combo1.set_entry_text_column(0)
         self.combo1.connect('changed', self._call)
 
         flip_btn = Gtk.Button()
@@ -56,17 +57,17 @@ class ConvertActivity(activity.Activity):
         flip_btn.add(Gtk.Image.new_from_file('icons/flip.svg'))
 
         self._liststore2 = Gtk.ListStore(str)
-        self.combo2 = Gtk.ComboBox.new_with_model_and_entry(self._liststore1)
+        self.combo2 = Gtk.ComboBox.new_with_model_and_entry(self._liststore2)
         cell = Gtk.CellRendererText()
         self.combo2.pack_start(cell, True)
         self.combo2.add_attribute(cell, 'markup', 0)
+        self.combo2.set_entry_text_column(0)
         self.combo2.connect('changed', self._call)
 
         self.label_box = Gtk.HBox()
 
-        self.adjustment = Gtk.Adjustment(1.0, 0.0000000001, 10.0 ** 20.0, 0.1,
-                                         1.0)
-        self.spin = Gtk.SpinButton() #self.adjustment, 0.0, 2)
+        self.adjustment = Gtk.Adjustment(1.0, 0, 10.00 ** 10.00 , 1.0, 1.0, 0)  
+        self.spin = Gtk.SpinButton() 
         self.spin.set_adjustment(self.adjustment)
 
         self.label = Gtk.Label()


### PR DESCRIPTION
Unit spinners no longer empty, still get this error 
"""
Traceback (most recent call last):
  File "/home/ibiam/Activities/convert/activity.py", line 206, in _call
    self._update_label()
  File "/home/ibiam/Activities/convert/activity.py", line 194, in _update_label
    new_convert = locale.format(fmt, float(convert_value))
ValueError: could not convert string to float: None
"""
Really rough commits though.