### PR TITLE
Removing convert button

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -52,7 +52,6 @@ class ConvertActivity(activity.Activity):
         cell = Gtk.CellRendererText()
         self.combo1.pack_start(cell, True)
         self.combo1.set_entry_text_column(0)
-        self.combo1.connect('changed', self._call)
 
         flip_btn = Gtk.Button()
         flip_btn.connect('clicked', self._flip)
@@ -62,14 +61,13 @@ class ConvertActivity(activity.Activity):
         cell = Gtk.CellRendererText()
         self.combo2.pack_start(cell, True)
         self.combo2.set_entry_text_column(0)
-        self.combo2.connect('changed', self._call)
 
         self.label_box = Gtk.HBox()
 
         self.value_entry = Gtk.Entry()
         self.value_entry.set_placeholder_text("Enter number")
         self.value_entry.connect('insert-text', self._value_insert_text)
-        self.value_entry.connect('changed', self._call)
+        self.value_entry.connect('changed', self._update_label)
 
         self.label = Gtk.Label()
         self.label.set_selectable(True)
@@ -178,7 +176,7 @@ class ConvertActivity(activity.Activity):
         self._update_combo(convert.length)
         self.show_all()
 
-    def _update_label(self):
+    def _update_label(self, entry):
         try:
             num_value = str(self.value_entry.get_text())
             num_value = str(num_value.replace(',',''))
@@ -193,15 +191,8 @@ class ConvertActivity(activity.Activity):
 
             text = '%s ~ %s' % (new_value, new_convert)
             self.label.set_text(text)
-        except KeyError:
+        except ValueError:
             pass
-
-    def _call(self, widget=None):
-        try:
-            self._update_label()
-        except:
-            pass
-        self.show_all()
 
     def _update_combo(self, data):
         self._liststore.clear()
@@ -220,7 +211,6 @@ class ConvertActivity(activity.Activity):
             self._liststore.append(['%s%s' % (x, symbol)])
         self.combo1.set_active(-1)
         self.combo2.set_active(-1)
-        self._call()
         self.show_all()
 
     def _get_active_text(self, combobox):
@@ -239,12 +229,9 @@ class ConvertActivity(activity.Activity):
         active_combo2 = self.combo2.get_active()
         self.combo1.set_active(active_combo2)
         self.combo2.set_active(active_combo1)
-        try:
-            value = float(self.label.get_text().split(' ~ ')[1])
-            self.value_entry.set_text(str(value))
-        except:
-            pass
-        self._call()
+        value = float(self.label.get_text().split(' ~ ')[1])
+        self.value_entry.set_text(str(value))
+        self._update_label(self.value_entry)
 
     def resize_label(self, widget, event):
         num_label = len(self.label.get_text())
@@ -270,4 +257,3 @@ class ConvertActivity(activity.Activity):
                 entry.emit_stop_by_name('insert-text')
                 return True
         return False
-

--- a/activity.py
+++ b/activity.py
@@ -52,6 +52,7 @@ class ConvertActivity(activity.Activity):
         cell = Gtk.CellRendererText()
         self.combo1.pack_start(cell, True)
         self.combo1.set_entry_text_column(0)
+        self.combo1.connect('changed', self._update_label)
 
         flip_btn = Gtk.Button()
         flip_btn.connect('clicked', self._flip)
@@ -61,6 +62,7 @@ class ConvertActivity(activity.Activity):
         cell = Gtk.CellRendererText()
         self.combo2.pack_start(cell, True)
         self.combo2.set_entry_text_column(0)
+        self.combo2.connect('changed', self._update_label)
 
         self.label_box = Gtk.HBox()
 

--- a/activity.py
+++ b/activity.py
@@ -67,16 +67,14 @@ class ConvertActivity(activity.Activity):
         self.label_box = Gtk.HBox()
 
         self.value_entry = Gtk.Entry()
-        self.value_entry.set_text("1")
+        self.value_entry.set_placeholder_text("Enter number")
         self.value_entry.connect('insert-text', self._value_insert_text)
+        self.value_entry.connect('changed', self._call)
 
         self.label = Gtk.Label()
         self.label.set_selectable(True)
         self.label._size = 12
         self.label.connect('draw', self.resize_label)
-
-        self.convert_btn = Gtk.Button(_('Convert'))
-        self.convert_btn.connect('clicked', self._call)
 
         self._canvas.pack_start(hbox, False, False, 20)
         hbox.pack_start(self.combo1, False, True, 20)
@@ -89,7 +87,6 @@ class ConvertActivity(activity.Activity):
         self._canvas.pack_start(convert_box, False, False, 5)
         self._canvas.pack_start(self.label_box, True, False, 0)
         self.label_box.add(self.label)
-        value_box.pack_start(self.convert_btn, False, False, 20)
 
         self.set_canvas(self._canvas)
 
@@ -200,7 +197,10 @@ class ConvertActivity(activity.Activity):
             pass
 
     def _call(self, widget=None):
-        self._update_label()
+        try:
+            self._update_label()
+        except:
+            pass
         self.show_all()
 
     def _update_combo(self, data):
@@ -239,8 +239,11 @@ class ConvertActivity(activity.Activity):
         active_combo2 = self.combo2.get_active()
         self.combo1.set_active(active_combo2)
         self.combo2.set_active(active_combo1)
-        value = float(self.label.get_text().split(' ~ ')[1])
-        self.value_entry.set_text(str(value))
+        try:
+            value = float(self.label.get_text().split(' ~ ')[1])
+            self.value_entry.set_text(str(value))
+        except:
+            pass
         self._call()
 
     def resize_label(self, widget, event):

--- a/activity.py
+++ b/activity.py
@@ -211,8 +211,8 @@ class ConvertActivity(activity.Activity):
                     symbol = " " + u'\u00b2'
 
             self._liststore.append(['%s%s' % (x, symbol)])
-        self.combo1.set_active(-1)
-        self.combo2.set_active(-1)
+        self.combo1.set_active(0)
+        self.combo2.set_active(0)
         self.show_all()
 
     def _get_active_text(self, combobox):

--- a/po/Convert.pot
+++ b/po/Convert.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-28 07:57+1000\n"
+"POT-Creation-Date: 2019-01-25 10:30+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: activity/activity.info:2 activity.py:75
+#: activity/activity.info:2
 msgid "Convert"
 msgstr ""
 


### PR DESCRIPTION
Previously the convert button has to be clicked to calculate results.

Now on pressing enter the activate signal will call the "_call" function
and results will be calculated.

Fixes https://github.com/sugarlabs/convert/issues/16