### PR TITLE
Redesign layout

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -60,12 +60,12 @@ class ConvertActivity(activity.Activity):
 
         self.from_value = Gtk.Entry()
         self.from_value.set_placeholder_text("Enter value")
-        self.from_value.connect('insert-text', self._value_insert_text)
+        self.from_value.connect('insert-text', self._insert_text_cb)
         self.from_value.connect('changed', self._from_changed_cb)
         self.from_value.override_font(input_font)
 
         self.to_value = Gtk.Entry()
-        self.to_value.connect('insert-text', self._value_insert_text)
+        self.to_value.connect('insert-text', self._insert_text_cb)
         self.to_value.connect('changed', self._to_changed_cb)
         self.to_value.override_font(input_font)
 
@@ -306,9 +306,9 @@ class ConvertActivity(activity.Activity):
     def change_result(self, new_value, new_convert, direction):
         if direction == 'from':
             self.to_value.handler_block_by_func(self._to_changed_cb)
-            self.to_value.handler_block_by_func(self._value_insert_text)
+            self.to_value.handler_block_by_func(self._insert_text_cb)
             self.to_value.set_text(new_convert)
-            self.to_value.handler_unblock_by_func(self._value_insert_text)
+            self.to_value.handler_unblock_by_func(self._insert_text_cb)
             self.to_value.handler_unblock_by_func(self._to_changed_cb)
 
             self.arrow.set_text("→")
@@ -324,9 +324,9 @@ class ConvertActivity(activity.Activity):
 
         elif direction == 'to':
             self.from_value.handler_block_by_func(self._from_changed_cb)
-            self.from_value.handler_block_by_func(self._value_insert_text)
+            self.from_value.handler_block_by_func(self._insert_text_cb)
             self.from_value.set_text(new_convert)
-            self.from_value.handler_unblock_by_func(self._value_insert_text)
+            self.from_value.handler_unblock_by_func(self._insert_text_cb)
             self.from_value.handler_unblock_by_func(self._from_changed_cb)
 
             self.arrow.set_text("←")
@@ -406,7 +406,7 @@ class ConvertActivity(activity.Activity):
             to_unit = self._get_active_text(self.from_unit)
         return convert.convert(num_value, unit, to_unit, self.dic)
 
-    def _value_insert_text(self, entry, text, length, position):
+    def _insert_text_cb(self, entry, text, length, position):
         for char in text:
             if char == "-" and \
                entry.get_text() is "" and len(text) == 1:

--- a/activity.py
+++ b/activity.py
@@ -44,9 +44,6 @@ class ConvertActivity(activity.Activity):
         self.max_participants = 1
         self.dic = {}
 
-        # Canvas
-        self._canvas = Gtk.VBox()
-
         self._liststore = Gtk.ListStore(str)
         arrow_font = Pango.FontDescription('sans bold 18')
         input_font = Pango.FontDescription('sans 12')
@@ -85,9 +82,9 @@ class ConvertActivity(activity.Activity):
         self.ratio._size = 12
         self.ratio.connect('draw', self._ratio_draw_cb)
 
-        l_hbox = Gtk.HBox()
-        u_hbox = Gtk.HBox()
-        label_box = Gtk.HBox()
+        l_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        u_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        label_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
         self.label1 = Gtk.Label()
         self.label1.set_markup('<big>From value</big>')
@@ -109,11 +106,11 @@ class ConvertActivity(activity.Activity):
         l_hbox.pack_end(self.to_unit, True, True, 5)
         label_box.add(self.ratio)
 
-        self._canvas.pack_start(u_hbox, False, False, 30)
-        self._canvas.pack_start(l_hbox, False, False, 0)
-        self._canvas.pack_start(label_box, True, False, 0)
-
-        self.set_canvas(self._canvas)
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        box.pack_start(u_hbox, False, False, 30)
+        box.pack_start(l_hbox, False, False, 0)
+        box.pack_start(label_box, True, False, 0)
+        self.set_canvas(box)
 
         # Toolbar
         toolbarbox = ToolbarBox()

--- a/activity.py
+++ b/activity.py
@@ -103,7 +103,6 @@ class ConvertActivity(activity.Activity):
 
         l_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         u_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-        label_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
         self.label1 = Gtk.Label()
         self.label1.set_markup('<big>From value</big>')
@@ -123,12 +122,11 @@ class ConvertActivity(activity.Activity):
         l_hbox.pack_start(self.arrow, False, False, 15)
         l_hbox.pack_start(self.to_value, True, True, 5)
         l_hbox.pack_end(self.to_unit, True, True, 5)
-        label_box.add(self.ratio)
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box.pack_start(u_hbox, False, False, 30)
         box.pack_start(l_hbox, False, False, 0)
-        box.pack_start(label_box, True, False, 0)
+        box.pack_start(self.ratio, True, False, 0)
         self.set_canvas(box)
 
         # Toolbar

--- a/activity.py
+++ b/activity.py
@@ -31,6 +31,7 @@ from sugar3.activity.widgets import StopButton
 from sugar3.activity.widgets import ActivityToolbarButton
 from sugar3.graphics.toolbarbox import ToolbarBox
 from sugar3.graphics.radiotoolbutton import RadioToolButton
+from sugar3.graphics.style import FONT_SIZE, FONT_FACE
 
 from gettext import gettext as _
 
@@ -41,7 +42,7 @@ class Ratio(Gtk.Label):
     def __init__(self):
         Gtk.Label.__init__(self)
         self.set_selectable(True)
-        self._size = 12  # TODO: use style.FONT_SIZE
+        self._size = -1
 
     def set_text(self, text):
         Gtk.Label.set_text(self, text)
@@ -49,9 +50,10 @@ class Ratio(Gtk.Label):
         if length == 0:
             return
 
-        size = str((60 * SCREEN_WIDTH / 100) / length)
+        size = (60 * SCREEN_WIDTH / 100) / length + int(FONT_SIZE * 1.2)
         if not size == self._size:
-            self.modify_font(Pango.FontDescription(size))
+            self.modify_font(Pango.FontDescription(
+                '%s %d' % (FONT_FACE, size)))
             self._size = size
 
 
@@ -63,8 +65,10 @@ class ConvertActivity(activity.Activity):
         self.dic = {}
 
         self._liststore = Gtk.ListStore(str)
-        arrow_font = Pango.FontDescription('sans bold 18')
-        input_font = Pango.FontDescription('sans 12')
+        arrow_font = Pango.FontDescription(
+            '%s %d' % (FONT_FACE, int(FONT_SIZE * 1.8)))
+        input_font = Pango.FontDescription(
+            '%s %d' % (FONT_FACE, int(FONT_SIZE * 1.2)))
 
         self.from_unit = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()

--- a/activity.py
+++ b/activity.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (C) 2012 Cristhofer Travieso <cristhofert97@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -48,53 +49,54 @@ class ConvertActivity(activity.Activity):
 
         self._liststore = Gtk.ListStore(str)
 
-        # Source Unit and Value
         self.combo1 = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()
         self.combo1.pack_start(cell, True)
         self.combo1.set_entry_text_column(0)
-        self.combo1.connect('changed', self._source_update)
+        self.combo1.connect('changed', self._from_update)
 
-        self.source_value_entry = Gtk.Entry()
-        self.source_value_entry.set_placeholder_text("Enter source number")
-        self.source_value_entry.connect('insert-text', self._value_insert_text)
-        self.source_value_entry.connect('changed', self._source_update)
+        self.from_value_entry = Gtk.Entry()
+        self.from_value_entry.set_placeholder_text("Enter source value")
+        self.from_value_entry.connect('insert-text', self._value_insert_text)
+        self.from_value_entry.connect('changed', self._from_update)
 
-        # Destination Value and Unit
-        self.destination_value_entry = Gtk.Entry()
-        self.destination_value_entry.set_placeholder_text("Enter destination number")
-        self.destination_value_entry.connect('insert-text', self._value_insert_text)
-        self.destination_value_entry.connect('changed', self._destination_update)
+        self.to_value_entry = Gtk.Entry()
+        self.to_value_entry.set_placeholder_text("Enter destination value")
+        self.to_value_entry.connect('insert-text', self._value_insert_text)
+        self.to_value_entry.connect('changed', self._to_update)
 
         self.combo2 = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()
         self.combo2.pack_start(cell, True)
         self.combo2.set_entry_text_column(0)
-        self.combo2.connect('changed', self._destination_update)
+        self.combo2.connect('changed', self._to_update)
 
+
+        input_font = Pango.FontDescription('sans bold 18')
         self.arrow_label = Gtk.Label()
-        self.arrow_label.set_text("=>")
+        self.arrow_label.override_font(input_font)
+        self.arrow_label.set_text("→")
 
         l_hbox = Gtk.HBox()
         u_hbox = Gtk.HBox()
 
-        label = Gtk.Label()
-        label.set_markup('<big>Source Value</big>')
-        u_hbox.pack_start(label, True, True, 5)
-        label = Gtk.Label()
-        label.set_markup('<big>Source Unit</big>')
-        u_hbox.pack_start(label, True, True, 20)
-        label = Gtk.Label()
-        label.set_markup('<big>Destination Value</big>')
-        u_hbox.pack_start(label, True, True, 20)
-        label = Gtk.Label()
-        label.set_markup('<big>Destination Unit</big>')
-        u_hbox.pack_start(label, True, True, 5)
+        self.label1 = Gtk.Label()
+        self.label1.set_markup('<big>From value</big>')
+        u_hbox.pack_start(self.label1, True, True, 5)
+        self.label2 = Gtk.Label()
+        self.label2.set_markup('<big>From unit</big>')
+        u_hbox.pack_start(self.label2, True, True, 20)
+        self.label3 = Gtk.Label()
+        self.label3.set_markup('<big>To value</big>')
+        u_hbox.pack_start(self.label3, True, True, 20)
+        self.label4 = Gtk.Label()
+        self.label4.set_markup('<big>To unit</big>')
+        u_hbox.pack_start(self.label4, True, True, 5)
 
-        l_hbox.pack_start(self.source_value_entry, True, True, 5)
+        l_hbox.pack_start(self.from_value_entry, True, True, 5)
         l_hbox.pack_start(self.combo1, True, True, 5)
         l_hbox.pack_start(self.arrow_label, False, False, 15)
-        l_hbox.pack_start(self.destination_value_entry, True, True, 5)
+        l_hbox.pack_start(self.to_value_entry, True, True, 5)
         l_hbox.pack_end(self.combo2, True, True, 5)
 
         self._canvas.pack_start(u_hbox, False, False, 30)
@@ -235,22 +237,22 @@ class ConvertActivity(activity.Activity):
         self._update_combo(convert.length)
         self.show_all()
 
-    def _source_update(self, widget):
-        direction = 'source'
+    def _from_update(self, widget):
+        direction = 'from'
         if isinstance(widget, Gtk.Entry):
             self._update_value(widget, direction)
         elif isinstance(widget, Gtk.ComboBox):
-            if self.arrow_label.get_text() == '<=':
-                direction = 'destination'
+            if self.arrow_label.get_text() == '←':
+                direction = 'to'
             self._update_unit(widget, direction)
 
-    def _destination_update(self, widget):
-        direction = 'destination'
+    def _to_update(self, widget):
+        direction = 'to'
         if isinstance(widget, Gtk.Entry):
             self._update_value(widget, direction)
         elif isinstance(widget, Gtk.ComboBox):
-            if self.arrow_label.get_text() == '=>':
-                direction = 'source'
+            if self.arrow_label.get_text() == '→':
+                direction = 'from'
             self._update_unit(widget, direction)
 
     def _update_value(self, entry, direction):
@@ -275,23 +277,33 @@ class ConvertActivity(activity.Activity):
             self.change_result('', '', direction)
 
     def _update_unit(self, combo, direction):
-        if direction == 'source':
-            self._update_value(self.source_value_entry, direction)
-        elif direction == 'destination':
-            self._update_value(self.destination_value_entry, direction)
+        if direction == 'from':
+            self._update_value(self.from_value_entry, direction)
+        elif direction == 'to':
+            self._update_value(self.to_value_entry, direction)
 
     def change_result(self, new_value, new_convert, direction):
-        if direction == 'source':
-            self.destination_value_entry.handler_block_by_func(self._value_insert_text)
-            self.destination_value_entry.set_text(new_convert)
-            self.destination_value_entry.handler_unblock_by_func(self._value_insert_text)
-            self.arrow_label.set_text("=>")
+        if direction == 'from':
+            self.to_value_entry.handler_block_by_func(self._value_insert_text)
+            self.to_value_entry.set_text(new_convert)
+            self.to_value_entry.handler_unblock_by_func(self._value_insert_text)
 
-        elif direction == 'destination':
-            self.source_value_entry.handler_block_by_func(self._value_insert_text)
-            self.source_value_entry.set_text(new_convert)
-            self.source_value_entry.handler_unblock_by_func(self._value_insert_text)
-            self.arrow_label.set_text("<=")
+            self.arrow_label.set_text("→")
+            self.label1.set_markup('<big>From value</big>')
+            self.label2.set_markup('<big>From unit</big>')
+            self.label3.set_markup('<big>To value</big>')
+            self.label4.set_markup('<big>To unit</big>')
+
+        elif direction == 'to':
+            self.from_value_entry.handler_block_by_func(self._value_insert_text)
+            self.from_value_entry.set_text(new_convert)
+            self.from_value_entry.handler_unblock_by_func(self._value_insert_text)
+
+            self.arrow_label.set_text("←")
+            self.label1.set_markup('<big>To value</big>')
+            self.label2.set_markup('<big>To unit</big>')
+            self.label3.set_markup('<big>From value</big>')
+            self.label4.set_markup('<big>From unit</big>')
 
     def _update_combo(self, data):
         self._liststore.clear()
@@ -352,10 +364,10 @@ class ConvertActivity(activity.Activity):
         return text
 
     def convert(self, num_value, direction):
-        if direction == 'source':
+        if direction == 'from':
             unit = self._get_active_text(self.combo1)
             to_unit = self._get_active_text(self.combo2)
-        elif direction == 'destination':
+        elif direction == 'to':
             unit = self._get_active_text(self.combo2)
             to_unit = self._get_active_text(self.combo1)
         return convert.convert(num_value, unit, to_unit, self.dic)

--- a/activity.py
+++ b/activity.py
@@ -59,13 +59,13 @@ class ConvertActivity(activity.Activity):
         self.combo1.override_font(input_font)
 
         self.from_value_entry = Gtk.Entry()
-        self.from_value_entry.set_placeholder_text("Enter source value")
+        self.from_value_entry.set_placeholder_text("Enter value")
         self.from_value_entry.connect('insert-text', self._value_insert_text)
         self.from_value_entry.connect('changed', self._from_update)
         self.from_value_entry.override_font(input_font)
 
         self.to_value_entry = Gtk.Entry()
-        self.to_value_entry.set_placeholder_text("Enter destination value")
+        self.to_value_entry.set_placeholder_text("Enter value")
         self.to_value_entry.connect('insert-text', self._value_insert_text)
         self.to_value_entry.connect('changed', self._to_update)
         self.to_value_entry.override_font(input_font)

--- a/activity.py
+++ b/activity.py
@@ -37,6 +37,24 @@ from gettext import gettext as _
 SCREEN_WIDTH = Gdk.Screen.width()
 
 
+class Ratio(Gtk.Label):
+    def __init__(self):
+        Gtk.Label.__init__(self)
+        self.set_selectable(True)
+        self._size = 12  # TODO: use style.FONT_SIZE
+        self.connect('draw', self.__draw_cb)
+
+    def __draw_cb(self, widget, cr):
+        length = len(widget.get_text())
+        if length == 0:
+            return
+
+        size = str((60 * SCREEN_WIDTH / 100) / length)
+        if not size == self._size:
+            self.modify_font(Pango.FontDescription(size))
+            self._size = size
+
+
 class ConvertActivity(activity.Activity):
     def __init__(self, handle):
         activity.Activity.__init__(self, handle, True)
@@ -77,10 +95,7 @@ class ConvertActivity(activity.Activity):
         self.arrow.override_font(arrow_font)
         self.arrow.set_text("→")
 
-        self.ratio = Gtk.Label()
-        self.ratio.set_selectable(True)
-        self.ratio._size = 12
-        self.ratio.connect('draw', self._ratio_draw_cb)
+        self.ratio = Ratio()
 
         l_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         u_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
@@ -244,16 +259,6 @@ class ConvertActivity(activity.Activity):
         self.set_toolbar_box(toolbarbox)
         self._update_combo(convert.length)
         self.show_all()
-
-    def _ratio_draw_cb(self, widget, cr):
-        num_label = len(self.ratio.get_text())
-        try:
-            size = str((60 * SCREEN_WIDTH / 100) / num_label)
-            if not size == self.ratio._size:
-                self.ratio.modify_font(Pango.FontDescription(size))
-                self.ratio._size = size
-        except ZeroDivisionError:
-            pass
 
     def _from_changed_cb(self, widget):
         direction = 'from'

--- a/activity.py
+++ b/activity.py
@@ -268,8 +268,7 @@ class ConvertActivity(activity.Activity):
                 new_convert = new_convert[0:len(new_convert)-1]
             self.change_result(new_value, new_convert, direction)
         except ValueError:
-            self.source_value_entry.set_text('')
-            self.destination_value_entry.set_text('')
+            self.change_result('', '', direction)
 
     def _update_unit(self, combo, direction):
         if direction == 'source':
@@ -279,24 +278,15 @@ class ConvertActivity(activity.Activity):
 
     def change_result(self, new_value, new_convert, direction):
         if direction == 'source':
-            self.source_value_entry.handler_block_by_func(self._source_update)
-            self.source_value_entry.set_text(new_value)
-            self.source_value_entry.handler_unblock_by_func(self._source_update)
-
-            self.destination_value_entry.handler_block_by_func(self._destination_update)
+            self.destination_value_entry.handler_block_by_func(self._value_insert_text)
             self.destination_value_entry.set_text(new_convert)
-            self.destination_value_entry.handler_unblock_by_func(self._destination_update)
-
+            self.destination_value_entry.handler_unblock_by_func(self._value_insert_text)
             self.arrow_label.set_text("=>")
+
         elif direction == 'destination':
-            self.destination_value_entry.handler_block_by_func(self._destination_update)
-            self.destination_value_entry.set_text(new_value)
-            self.destination_value_entry.handler_unblock_by_func(self._destination_update)
-
-            self.source_value_entry.handler_block_by_func(self._source_update)
+            self.source_value_entry.handler_block_by_func(self._value_insert_text)
             self.source_value_entry.set_text(new_convert)
-            self.source_value_entry.handler_unblock_by_func(self._source_update)
-
+            self.source_value_entry.handler_unblock_by_func(self._value_insert_text)
             self.arrow_label.set_text("<=")
 
     def _update_combo(self, data):

--- a/activity.py
+++ b/activity.py
@@ -51,12 +51,12 @@ class ConvertActivity(activity.Activity):
         arrow_font = Pango.FontDescription('sans bold 18')
         input_font = Pango.FontDescription('sans 12')
 
-        self.combo1 = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
+        self.from_unit = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()
-        self.combo1.pack_start(cell, True)
-        self.combo1.set_entry_text_column(0)
-        self.combo1.connect('changed', self._from_update)
-        self.combo1.override_font(input_font)
+        self.from_unit.pack_start(cell, True)
+        self.from_unit.set_entry_text_column(0)
+        self.from_unit.connect('changed', self._from_update)
+        self.from_unit.override_font(input_font)
 
         self.from_value_entry = Gtk.Entry()
         self.from_value_entry.set_placeholder_text("Enter value")
@@ -69,12 +69,12 @@ class ConvertActivity(activity.Activity):
         self.to_value_entry.connect('changed', self._to_update)
         self.to_value_entry.override_font(input_font)
 
-        self.combo2 = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
+        self.to_unit = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()
-        self.combo2.pack_start(cell, True)
-        self.combo2.set_entry_text_column(0)
-        self.combo2.connect('changed', self._to_update)
-        self.combo2.override_font(input_font)
+        self.to_unit.pack_start(cell, True)
+        self.to_unit.set_entry_text_column(0)
+        self.to_unit.connect('changed', self._to_update)
+        self.to_unit.override_font(input_font)
 
         self.arrow_label = Gtk.Label()
         self.arrow_label.override_font(arrow_font)
@@ -103,10 +103,10 @@ class ConvertActivity(activity.Activity):
         u_hbox.pack_start(self.label4, True, True, 5)
 
         l_hbox.pack_start(self.from_value_entry, True, True, 5)
-        l_hbox.pack_start(self.combo1, True, True, 5)
+        l_hbox.pack_start(self.from_unit, True, True, 5)
         l_hbox.pack_start(self.arrow_label, False, False, 15)
         l_hbox.pack_start(self.to_value_entry, True, True, 5)
-        l_hbox.pack_end(self.combo2, True, True, 5)
+        l_hbox.pack_end(self.to_unit, True, True, 5)
         label_box.add(self.label)
 
         self._canvas.pack_start(u_hbox, False, False, 30)
@@ -317,7 +317,7 @@ class ConvertActivity(activity.Activity):
             self.label3.set_markup('<big>To value</big>')
             self.label4.set_markup('<big>To unit</big>')
             if new_convert != '' and new_value != '':
-                text = '%s %s ~ %s %s' % (new_value, self._get_active_text(self.combo1), new_convert, self._get_active_text(self.combo2))
+                text = '%s %s ~ %s %s' % (new_value, self._get_active_text(self.from_unit), new_convert, self._get_active_text(self.to_unit))
                 self.label.set_text(text)
             else:
                 self.label.set_text('')
@@ -335,7 +335,7 @@ class ConvertActivity(activity.Activity):
             self.label3.set_markup('<big>From value</big>')
             self.label4.set_markup('<big>From unit</big>')
             if new_convert != '' and new_value != '':
-                text = '%s %s ~ %s %s' % (new_convert, self._get_active_text(self.combo1), new_value, self._get_active_text(self.combo2))
+                text = '%s %s ~ %s %s' % (new_convert, self._get_active_text(self.from_unit), new_value, self._get_active_text(self.to_unit))
                 self.label.set_text(text)
             else:
                 self.label.set_text('')
@@ -347,41 +347,41 @@ class ConvertActivity(activity.Activity):
         for x in keys:
             self._liststore.append(['%s' % (x)])
         if keys[0] == 'Cables':
-            self.combo1.set_active(12)
-            self.combo2.set_active(12)
+            self.from_unit.set_active(12)
+            self.to_unit.set_active(12)
         elif keys[0] == 'Cubic Centimeter':
-            self.combo1.set_active(3)
-            self.combo2.set_active(3)
+            self.from_unit.set_active(3)
+            self.to_unit.set_active(3)
         elif keys[0] == 'Acre':
-            self.combo1.set_active(4)
-            self.combo2.set_active(4)
+            self.from_unit.set_active(4)
+            self.to_unit.set_active(4)
         elif keys[0] == 'Carat':
-            self.combo1.set_active(2)
-            self.combo2.set_active(2)
+            self.from_unit.set_active(2)
+            self.to_unit.set_active(2)
         elif keys[0] == 'Centimeters/Minute':
-            self.combo1.set_active(9)
-            self.combo2.set_active(9)
+            self.from_unit.set_active(9)
+            self.to_unit.set_active(9)
         elif keys[0] == 'Day':
-            self.combo1.set_active(8)
-            self.combo2.set_active(8)
+            self.from_unit.set_active(8)
+            self.to_unit.set_active(8)
         elif keys[0] == 'Celsius':
-            self.combo1.set_active(2)
-            self.combo2.set_active(2)
+            self.from_unit.set_active(2)
+            self.to_unit.set_active(2)
         elif keys[0] == 'Degrees':
-            self.combo1.set_active(1)
-            self.combo2.set_active(1)
+            self.from_unit.set_active(1)
+            self.to_unit.set_active(1)
         elif keys[0] == 'Atmosphere (atm)':
-            self.combo1.set_active(2)
-            self.combo2.set_active(2)
+            self.from_unit.set_active(2)
+            self.to_unit.set_active(2)
         elif keys[0] == 'Dyne (dyn)':
-            self.combo1.set_active(2)
-            self.combo2.set_active(2)
+            self.from_unit.set_active(2)
+            self.to_unit.set_active(2)
         elif keys[0] == 'Calories (cal)':
-            self.combo1.set_active(2)
-            self.combo2.set_active(2)
+            self.from_unit.set_active(2)
+            self.to_unit.set_active(2)
         elif keys[0] == 'Bit':
-            self.combo1.set_active(1)
-            self.combo2.set_active(1)
+            self.from_unit.set_active(1)
+            self.to_unit.set_active(1)
         else:
             pass
         self.show_all()
@@ -399,11 +399,11 @@ class ConvertActivity(activity.Activity):
 
     def convert(self, num_value, direction):
         if direction == 'from':
-            unit = self._get_active_text(self.combo1)
-            to_unit = self._get_active_text(self.combo2)
+            unit = self._get_active_text(self.from_unit)
+            to_unit = self._get_active_text(self.to_unit)
         elif direction == 'to':
-            unit = self._get_active_text(self.combo2)
-            to_unit = self._get_active_text(self.combo1)
+            unit = self._get_active_text(self.to_unit)
+            to_unit = self._get_active_text(self.from_unit)
         return convert.convert(num_value, unit, to_unit, self.dic)
 
     def _value_insert_text(self, entry, text, length, position):

--- a/activity.py
+++ b/activity.py
@@ -259,12 +259,7 @@ class ConvertActivity(activity.Activity):
         try:
             num_value = str(entry.get_text())
             num_value = float(num_value.replace(',', ''))
-            decimals = str(len(str(num_value).split('.')[-1]))
-            fmt = '%.' + decimals + 'f'
-            new_value = locale.format(fmt, float(num_value))
-            new_value = new_value.rstrip("0")
-            if new_value[-1] == '.':
-                new_value = new_value[0:len(new_value)-1]
+
             convert_value = str(self.convert(num_value, direction))
             decimals = str(len(convert_value.split('.')[-1]))
             fmt = '%.' + decimals + 'f'
@@ -272,9 +267,9 @@ class ConvertActivity(activity.Activity):
             new_convert = new_convert.rstrip("0")
             if new_convert[-1] == '.':
                 new_convert = new_convert[0:len(new_convert)-1]
-            self.change_result(new_value, new_convert, direction)
+            self.change_result(new_convert, direction)
         except ValueError:
-            self.change_result('', '', direction)
+            self.change_result('', direction)
 
     def _update_unit(self, combo, direction):
         if direction == 'from':
@@ -282,7 +277,7 @@ class ConvertActivity(activity.Activity):
         elif direction == 'to':
             self._update_value(self.to_value_entry, direction)
 
-    def change_result(self, new_value, new_convert, direction):
+    def change_result(self, new_convert, direction):
         if direction == 'from':
             self.to_value_entry.handler_block_by_func(self._value_insert_text)
             self.to_value_entry.set_text(new_convert)

--- a/activity.py
+++ b/activity.py
@@ -83,7 +83,7 @@ class ConvertActivity(activity.Activity):
         self.ratio = Gtk.Label()
         self.ratio.set_selectable(True)
         self.ratio._size = 12
-        self.ratio.connect('draw', self.resize_label)
+        self.ratio.connect('draw', self._ratio_draw_cb)
 
         l_hbox = Gtk.HBox()
         u_hbox = Gtk.HBox()
@@ -248,7 +248,7 @@ class ConvertActivity(activity.Activity):
         self._update_combo(convert.length)
         self.show_all()
 
-    def resize_label(self, widget, event):
+    def _ratio_draw_cb(self, widget, cr):
         num_label = len(self.ratio.get_text())
         try:
             size = str((60 * SCREEN_WIDTH / 100) / num_label)

--- a/activity.py
+++ b/activity.py
@@ -279,9 +279,11 @@ class ConvertActivity(activity.Activity):
 
     def change_result(self, new_convert, direction):
         if direction == 'from':
+            self.to_value_entry.handler_block_by_func(self._to_update)
             self.to_value_entry.handler_block_by_func(self._value_insert_text)
             self.to_value_entry.set_text(new_convert)
             self.to_value_entry.handler_unblock_by_func(self._value_insert_text)
+            self.to_value_entry.handler_unblock_by_func(self._to_update)
 
             self.arrow_label.set_text("→")
             self.label1.set_markup('<big>From value</big>')
@@ -290,9 +292,11 @@ class ConvertActivity(activity.Activity):
             self.label4.set_markup('<big>To unit</big>')
 
         elif direction == 'to':
+            self.from_value_entry.handler_block_by_func(self._from_update)
             self.from_value_entry.handler_block_by_func(self._value_insert_text)
             self.from_value_entry.set_text(new_convert)
             self.from_value_entry.handler_unblock_by_func(self._value_insert_text)
+            self.from_value_entry.handler_unblock_by_func(self._from_update)
 
             self.arrow_label.set_text("←")
             self.label1.set_markup('<big>To value</big>')

--- a/activity.py
+++ b/activity.py
@@ -35,8 +35,6 @@ from sugar3.graphics.style import FONT_SIZE, FONT_FACE
 
 from gettext import gettext as _
 
-SCREEN_WIDTH = Gdk.Screen.width()
-
 
 class Ratio(Gtk.Label):
     def __init__(self):
@@ -50,7 +48,8 @@ class Ratio(Gtk.Label):
         if length == 0:
             return
 
-        size = (60 * SCREEN_WIDTH / 100) / length + int(FONT_SIZE * 1.2)
+        width = self.get_allocation().width
+        size = (60 * width / 100) / length + int(FONT_SIZE * 1.2)
         if not size == self._size:
             self.modify_font(Pango.FontDescription(
                 '%s %d' % (FONT_FACE, size)))
@@ -258,15 +257,9 @@ class ConvertActivity(activity.Activity):
         stopbtn = StopButton(self)
         toolbarbox.toolbar.insert(stopbtn, -1)
 
-        self.connect('size-allocate', self._size_allocate_cb)
-
         self.set_toolbar_box(toolbarbox)
         self._update_combo(convert.length)
         self.show_all()
-
-    def _size_allocate_cb(self, widget, allocation):
-        global SCREEN_WIDTH
-        SCREEN_WIDTH = allocation.width
 
     def _from_changed_cb(self, widget):
         direction = 'from'

--- a/activity.py
+++ b/activity.py
@@ -81,8 +81,14 @@ class ConvertActivity(activity.Activity):
         self.arrow_label.override_font(arrow_font)
         self.arrow_label.set_text("→")
 
+        self.label = Gtk.Label()
+        self.label.set_selectable(True)
+        self.label._size = 12
+        self.label.connect('draw', self.resize_label)
+
         l_hbox = Gtk.HBox()
         u_hbox = Gtk.HBox()
+        label_box = Gtk.HBox()
 
         self.label1 = Gtk.Label()
         self.label1.set_markup('<big>From value</big>')
@@ -102,9 +108,11 @@ class ConvertActivity(activity.Activity):
         l_hbox.pack_start(self.arrow_label, False, False, 15)
         l_hbox.pack_start(self.to_value_entry, True, True, 5)
         l_hbox.pack_end(self.combo2, True, True, 5)
+        label_box.add(self.label)
 
         self._canvas.pack_start(u_hbox, False, False, 30)
         self._canvas.pack_start(l_hbox, False, False, 0)
+        self._canvas.pack_start(label_box, True, False, 0)
 
         self.set_canvas(self._canvas)
 
@@ -241,6 +249,16 @@ class ConvertActivity(activity.Activity):
         self._update_combo(convert.length)
         self.show_all()
 
+    def resize_label(self, widget, event):
+        num_label = len(self.label.get_text())
+        try:
+            size = str((60 * SCREEN_WIDTH / 100) / num_label)
+            if not size == self.label._size:
+                self.label.modify_font(Pango.FontDescription(size))
+                self.label._size = size
+        except ZeroDivisionError:
+            pass
+
     def _from_update(self, widget):
         direction = 'from'
         if isinstance(widget, Gtk.Entry):
@@ -299,6 +317,11 @@ class ConvertActivity(activity.Activity):
             self.label2.set_markup('<big>From unit</big>')
             self.label3.set_markup('<big>To value</big>')
             self.label4.set_markup('<big>To unit</big>')
+            if new_convert != '' and new_value != '':
+                text = '%s %s ~ %s %s' % (new_value, self._get_active_text(self.combo1), new_convert, self._get_active_text(self.combo2))
+                self.label.set_text(text)
+            else:
+                self.label.set_text('')
 
         elif direction == 'to':
             self.from_value_entry.handler_block_by_func(self._from_update)
@@ -312,7 +335,11 @@ class ConvertActivity(activity.Activity):
             self.label2.set_markup('<big>To unit</big>')
             self.label3.set_markup('<big>From value</big>')
             self.label4.set_markup('<big>From unit</big>')
-
+            if new_convert != '' and new_value != '':
+                text = '%s %s ~ %s %s' % (new_convert, self._get_active_text(self.combo1), new_value, self._get_active_text(self.combo2))
+                self.label.set_text(text)
+            else:
+                self.label.set_text('')
     def _update_combo(self, data):
         self._liststore.clear()
         self.dic = data

--- a/activity.py
+++ b/activity.py
@@ -46,7 +46,6 @@ class ConvertActivity(activity.Activity):
         # Canvas
         self._canvas = Gtk.VBox()
 
-        hbox = Gtk.HBox()
         self._liststore = Gtk.ListStore(str)
 
         # Source Unit and Value
@@ -73,11 +72,33 @@ class ConvertActivity(activity.Activity):
         self.combo2.set_entry_text_column(0)
         self.combo2.connect('changed', self._destination_update)
 
-        self._canvas.pack_start(hbox, False, False, 20)
-        hbox.pack_start(self.combo1, False, True, 20)
-        hbox.pack_start(self.source_value_entry, True, True, 5)
-        hbox.pack_start(self.destination_value_entry, True, True, 5)
-        hbox.pack_end(self.combo2, False, True, 20)
+        self.arrow_label = Gtk.Label()
+        self.arrow_label.set_text("=>")
+
+        l_hbox = Gtk.HBox()
+        u_hbox = Gtk.HBox()
+
+        label = Gtk.Label()
+        label.set_markup('<big>Source Value</big>')
+        u_hbox.pack_start(label, True, True, 5)
+        label = Gtk.Label()
+        label.set_markup('<big>Source Unit</big>')
+        u_hbox.pack_start(label, True, True, 20)
+        label = Gtk.Label()
+        label.set_markup('<big>Destination Value</big>')
+        u_hbox.pack_start(label, True, True, 20)
+        label = Gtk.Label()
+        label.set_markup('<big>Destination Unit</big>')
+        u_hbox.pack_start(label, True, True, 5)
+
+        l_hbox.pack_start(self.source_value_entry, True, True, 5)
+        l_hbox.pack_start(self.combo1, True, True, 5)
+        l_hbox.pack_start(self.arrow_label, False, False, 15)
+        l_hbox.pack_start(self.destination_value_entry, True, True, 5)
+        l_hbox.pack_end(self.combo2, True, True, 5)
+
+        self._canvas.pack_start(u_hbox, False, False, 20)
+        self._canvas.pack_start(l_hbox, False, False, 5)
 
         self.set_canvas(self._canvas)
 
@@ -238,7 +259,6 @@ class ConvertActivity(activity.Activity):
             new_value = new_value.rstrip("0")
             if new_value[-1] == '.':
                 new_value = new_value[0:len(new_value)-1]
-
             convert_value = str(self.convert(num_value, direction))
             decimals = str(len(convert_value.split('.')[-1]))
             fmt = '%.' + decimals + 'f'
@@ -246,10 +266,10 @@ class ConvertActivity(activity.Activity):
             new_convert = new_convert.rstrip("0")
             if new_convert[-1] == '.':
                 new_convert = new_convert[0:len(new_convert)-1]
-
             self.change_result(new_value, new_convert, direction)
         except ValueError:
-            pass
+            self.source_value_entry.set_text('')
+            self.destination_value_entry.set_text('')
 
     def _update_unit(self, combo, direction):
         if direction == 'source':
@@ -266,6 +286,8 @@ class ConvertActivity(activity.Activity):
             self.destination_value_entry.handler_block_by_func(self._destination_update)
             self.destination_value_entry.set_text(new_convert)
             self.destination_value_entry.handler_unblock_by_func(self._destination_update)
+
+            self.arrow_label.set_text("=>")
         elif direction == 'destination':
             self.destination_value_entry.handler_block_by_func(self._destination_update)
             self.destination_value_entry.set_text(new_value)
@@ -274,6 +296,8 @@ class ConvertActivity(activity.Activity):
             self.source_value_entry.handler_block_by_func(self._source_update)
             self.source_value_entry.set_text(new_convert)
             self.source_value_entry.handler_unblock_by_func(self._source_update)
+
+            self.arrow_label.set_text("<=")
 
     def _update_combo(self, data):
         self._liststore.clear()

--- a/activity.py
+++ b/activity.py
@@ -58,16 +58,16 @@ class ConvertActivity(activity.Activity):
         self.from_unit.connect('changed', self._from_update)
         self.from_unit.override_font(input_font)
 
-        self.from_value_entry = Gtk.Entry()
-        self.from_value_entry.set_placeholder_text("Enter value")
-        self.from_value_entry.connect('insert-text', self._value_insert_text)
-        self.from_value_entry.connect('changed', self._from_update)
-        self.from_value_entry.override_font(input_font)
+        self.from_value = Gtk.Entry()
+        self.from_value.set_placeholder_text("Enter value")
+        self.from_value.connect('insert-text', self._value_insert_text)
+        self.from_value.connect('changed', self._from_update)
+        self.from_value.override_font(input_font)
 
-        self.to_value_entry = Gtk.Entry()
-        self.to_value_entry.connect('insert-text', self._value_insert_text)
-        self.to_value_entry.connect('changed', self._to_update)
-        self.to_value_entry.override_font(input_font)
+        self.to_value = Gtk.Entry()
+        self.to_value.connect('insert-text', self._value_insert_text)
+        self.to_value.connect('changed', self._to_update)
+        self.to_value.override_font(input_font)
 
         self.to_unit = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()
@@ -102,10 +102,10 @@ class ConvertActivity(activity.Activity):
         self.label4.set_markup('<big>To unit</big>')
         u_hbox.pack_start(self.label4, True, True, 5)
 
-        l_hbox.pack_start(self.from_value_entry, True, True, 5)
+        l_hbox.pack_start(self.from_value, True, True, 5)
         l_hbox.pack_start(self.from_unit, True, True, 5)
         l_hbox.pack_start(self.arrow_label, False, False, 15)
-        l_hbox.pack_start(self.to_value_entry, True, True, 5)
+        l_hbox.pack_start(self.to_value, True, True, 5)
         l_hbox.pack_end(self.to_unit, True, True, 5)
         label_box.add(self.label)
 
@@ -299,17 +299,17 @@ class ConvertActivity(activity.Activity):
 
     def _update_unit(self, combo, direction):
         if direction == 'from':
-            self._update_value(self.from_value_entry, direction)
+            self._update_value(self.from_value, direction)
         elif direction == 'to':
-            self._update_value(self.to_value_entry, direction)
+            self._update_value(self.to_value, direction)
 
     def change_result(self, new_value, new_convert, direction):
         if direction == 'from':
-            self.to_value_entry.handler_block_by_func(self._to_update)
-            self.to_value_entry.handler_block_by_func(self._value_insert_text)
-            self.to_value_entry.set_text(new_convert)
-            self.to_value_entry.handler_unblock_by_func(self._value_insert_text)
-            self.to_value_entry.handler_unblock_by_func(self._to_update)
+            self.to_value.handler_block_by_func(self._to_update)
+            self.to_value.handler_block_by_func(self._value_insert_text)
+            self.to_value.set_text(new_convert)
+            self.to_value.handler_unblock_by_func(self._value_insert_text)
+            self.to_value.handler_unblock_by_func(self._to_update)
 
             self.arrow_label.set_text("→")
             self.label1.set_markup('<big>From value</big>')
@@ -323,11 +323,11 @@ class ConvertActivity(activity.Activity):
                 self.label.set_text('')
 
         elif direction == 'to':
-            self.from_value_entry.handler_block_by_func(self._from_update)
-            self.from_value_entry.handler_block_by_func(self._value_insert_text)
-            self.from_value_entry.set_text(new_convert)
-            self.from_value_entry.handler_unblock_by_func(self._value_insert_text)
-            self.from_value_entry.handler_unblock_by_func(self._from_update)
+            self.from_value.handler_block_by_func(self._from_update)
+            self.from_value.handler_block_by_func(self._value_insert_text)
+            self.from_value.set_text(new_convert)
+            self.from_value.handler_unblock_by_func(self._value_insert_text)
+            self.from_value.handler_unblock_by_func(self._from_update)
 
             self.arrow_label.set_text("←")
             self.label1.set_markup('<big>To value</big>')

--- a/activity.py
+++ b/activity.py
@@ -65,7 +65,6 @@ class ConvertActivity(activity.Activity):
         self.from_value_entry.override_font(input_font)
 
         self.to_value_entry = Gtk.Entry()
-        self.to_value_entry.set_placeholder_text("Enter value")
         self.to_value_entry.connect('insert-text', self._value_insert_text)
         self.to_value_entry.connect('changed', self._to_update)
         self.to_value_entry.override_font(input_font)

--- a/activity.py
+++ b/activity.py
@@ -76,9 +76,9 @@ class ConvertActivity(activity.Activity):
         self.to_unit.connect('changed', self._to_update)
         self.to_unit.override_font(input_font)
 
-        self.arrow_label = Gtk.Label()
-        self.arrow_label.override_font(arrow_font)
-        self.arrow_label.set_text("→")
+        self.arrow = Gtk.Label()
+        self.arrow.override_font(arrow_font)
+        self.arrow.set_text("→")
 
         self.label = Gtk.Label()
         self.label.set_selectable(True)
@@ -104,7 +104,7 @@ class ConvertActivity(activity.Activity):
 
         l_hbox.pack_start(self.from_value, True, True, 5)
         l_hbox.pack_start(self.from_unit, True, True, 5)
-        l_hbox.pack_start(self.arrow_label, False, False, 15)
+        l_hbox.pack_start(self.arrow, False, False, 15)
         l_hbox.pack_start(self.to_value, True, True, 5)
         l_hbox.pack_end(self.to_unit, True, True, 5)
         label_box.add(self.label)
@@ -263,7 +263,7 @@ class ConvertActivity(activity.Activity):
         if isinstance(widget, Gtk.Entry):
             self._update_value(widget, direction)
         elif isinstance(widget, Gtk.ComboBox):
-            if self.arrow_label.get_text() == '←':
+            if self.arrow.get_text() == '←':
                 direction = 'to'
             self._update_unit(widget, direction)
 
@@ -272,7 +272,7 @@ class ConvertActivity(activity.Activity):
         if isinstance(widget, Gtk.Entry):
             self._update_value(widget, direction)
         elif isinstance(widget, Gtk.ComboBox):
-            if self.arrow_label.get_text() == '→':
+            if self.arrow.get_text() == '→':
                 direction = 'from'
             self._update_unit(widget, direction)
 
@@ -311,7 +311,7 @@ class ConvertActivity(activity.Activity):
             self.to_value.handler_unblock_by_func(self._value_insert_text)
             self.to_value.handler_unblock_by_func(self._to_update)
 
-            self.arrow_label.set_text("→")
+            self.arrow.set_text("→")
             self.label1.set_markup('<big>From value</big>')
             self.label2.set_markup('<big>From unit</big>')
             self.label3.set_markup('<big>To value</big>')
@@ -329,7 +329,7 @@ class ConvertActivity(activity.Activity):
             self.from_value.handler_unblock_by_func(self._value_insert_text)
             self.from_value.handler_unblock_by_func(self._from_update)
 
-            self.arrow_label.set_text("←")
+            self.arrow.set_text("←")
             self.label1.set_markup('<big>To value</big>')
             self.label2.set_markup('<big>To unit</big>')
             self.label3.set_markup('<big>From value</big>')

--- a/activity.py
+++ b/activity.py
@@ -42,10 +42,10 @@ class Ratio(Gtk.Label):
         Gtk.Label.__init__(self)
         self.set_selectable(True)
         self._size = 12  # TODO: use style.FONT_SIZE
-        self.connect('draw', self.__draw_cb)
 
-    def __draw_cb(self, widget, cr):
-        length = len(widget.get_text())
+    def set_text(self, text):
+        Gtk.Label.set_text(self, text)
+        length = len(text)
         if length == 0:
             return
 

--- a/activity.py
+++ b/activity.py
@@ -258,9 +258,15 @@ class ConvertActivity(activity.Activity):
         stopbtn = StopButton(self)
         toolbarbox.toolbar.insert(stopbtn, -1)
 
+        self.connect('size-allocate', self._size_allocate_cb)
+
         self.set_toolbar_box(toolbarbox)
         self._update_combo(convert.length)
         self.show_all()
+
+    def _size_allocate_cb(self, widget, allocation):
+        global SCREEN_WIDTH
+        SCREEN_WIDTH = int(allocation.width)
 
     def _from_changed_cb(self, widget):
         direction = 'from'

--- a/activity.py
+++ b/activity.py
@@ -80,10 +80,10 @@ class ConvertActivity(activity.Activity):
         self.arrow.override_font(arrow_font)
         self.arrow.set_text("→")
 
-        self.label = Gtk.Label()
-        self.label.set_selectable(True)
-        self.label._size = 12
-        self.label.connect('draw', self.resize_label)
+        self.ratio = Gtk.Label()
+        self.ratio.set_selectable(True)
+        self.ratio._size = 12
+        self.ratio.connect('draw', self.resize_label)
 
         l_hbox = Gtk.HBox()
         u_hbox = Gtk.HBox()
@@ -107,7 +107,7 @@ class ConvertActivity(activity.Activity):
         l_hbox.pack_start(self.arrow, False, False, 15)
         l_hbox.pack_start(self.to_value, True, True, 5)
         l_hbox.pack_end(self.to_unit, True, True, 5)
-        label_box.add(self.label)
+        label_box.add(self.ratio)
 
         self._canvas.pack_start(u_hbox, False, False, 30)
         self._canvas.pack_start(l_hbox, False, False, 0)
@@ -249,12 +249,12 @@ class ConvertActivity(activity.Activity):
         self.show_all()
 
     def resize_label(self, widget, event):
-        num_label = len(self.label.get_text())
+        num_label = len(self.ratio.get_text())
         try:
             size = str((60 * SCREEN_WIDTH / 100) / num_label)
-            if not size == self.label._size:
-                self.label.modify_font(Pango.FontDescription(size))
-                self.label._size = size
+            if not size == self.ratio._size:
+                self.ratio.modify_font(Pango.FontDescription(size))
+                self.ratio._size = size
         except ZeroDivisionError:
             pass
 
@@ -318,9 +318,9 @@ class ConvertActivity(activity.Activity):
             self.label4.set_markup('<big>To unit</big>')
             if new_convert != '' and new_value != '':
                 text = '%s %s ~ %s %s' % (new_value, self._get_active_text(self.from_unit), new_convert, self._get_active_text(self.to_unit))
-                self.label.set_text(text)
+                self.ratio.set_text(text)
             else:
-                self.label.set_text('')
+                self.ratio.set_text('')
 
         elif direction == 'to':
             self.from_value.handler_block_by_func(self._from_update)
@@ -336,9 +336,9 @@ class ConvertActivity(activity.Activity):
             self.label4.set_markup('<big>From unit</big>')
             if new_convert != '' and new_value != '':
                 text = '%s %s ~ %s %s' % (new_convert, self._get_active_text(self.from_unit), new_value, self._get_active_text(self.to_unit))
-                self.label.set_text(text)
+                self.ratio.set_text(text)
             else:
-                self.label.set_text('')
+                self.ratio.set_text('')
     def _update_combo(self, data):
         self._liststore.clear()
         self.dic = data

--- a/activity.py
+++ b/activity.py
@@ -55,25 +55,25 @@ class ConvertActivity(activity.Activity):
         cell = Gtk.CellRendererText()
         self.from_unit.pack_start(cell, True)
         self.from_unit.set_entry_text_column(0)
-        self.from_unit.connect('changed', self._from_update)
+        self.from_unit.connect('changed', self._from_changed_cb)
         self.from_unit.override_font(input_font)
 
         self.from_value = Gtk.Entry()
         self.from_value.set_placeholder_text("Enter value")
         self.from_value.connect('insert-text', self._value_insert_text)
-        self.from_value.connect('changed', self._from_update)
+        self.from_value.connect('changed', self._from_changed_cb)
         self.from_value.override_font(input_font)
 
         self.to_value = Gtk.Entry()
         self.to_value.connect('insert-text', self._value_insert_text)
-        self.to_value.connect('changed', self._to_update)
+        self.to_value.connect('changed', self._to_changed_cb)
         self.to_value.override_font(input_font)
 
         self.to_unit = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()
         self.to_unit.pack_start(cell, True)
         self.to_unit.set_entry_text_column(0)
-        self.to_unit.connect('changed', self._to_update)
+        self.to_unit.connect('changed', self._to_changed_cb)
         self.to_unit.override_font(input_font)
 
         self.arrow = Gtk.Label()
@@ -258,7 +258,7 @@ class ConvertActivity(activity.Activity):
         except ZeroDivisionError:
             pass
 
-    def _from_update(self, widget):
+    def _from_changed_cb(self, widget):
         direction = 'from'
         if isinstance(widget, Gtk.Entry):
             self._update_value(widget, direction)
@@ -267,7 +267,7 @@ class ConvertActivity(activity.Activity):
                 direction = 'to'
             self._update_unit(widget, direction)
 
-    def _to_update(self, widget):
+    def _to_changed_cb(self, widget):
         direction = 'to'
         if isinstance(widget, Gtk.Entry):
             self._update_value(widget, direction)
@@ -305,11 +305,11 @@ class ConvertActivity(activity.Activity):
 
     def change_result(self, new_value, new_convert, direction):
         if direction == 'from':
-            self.to_value.handler_block_by_func(self._to_update)
+            self.to_value.handler_block_by_func(self._to_changed_cb)
             self.to_value.handler_block_by_func(self._value_insert_text)
             self.to_value.set_text(new_convert)
             self.to_value.handler_unblock_by_func(self._value_insert_text)
-            self.to_value.handler_unblock_by_func(self._to_update)
+            self.to_value.handler_unblock_by_func(self._to_changed_cb)
 
             self.arrow.set_text("→")
             self.label1.set_markup('<big>From value</big>')
@@ -323,11 +323,11 @@ class ConvertActivity(activity.Activity):
                 self.ratio.set_text('')
 
         elif direction == 'to':
-            self.from_value.handler_block_by_func(self._from_update)
+            self.from_value.handler_block_by_func(self._from_changed_cb)
             self.from_value.handler_block_by_func(self._value_insert_text)
             self.from_value.set_text(new_convert)
             self.from_value.handler_unblock_by_func(self._value_insert_text)
-            self.from_value.handler_unblock_by_func(self._from_update)
+            self.from_value.handler_unblock_by_func(self._from_changed_cb)
 
             self.arrow.set_text("←")
             self.label1.set_markup('<big>To value</big>')

--- a/activity.py
+++ b/activity.py
@@ -263,7 +263,12 @@ class ConvertActivity(activity.Activity):
         try:
             num_value = str(entry.get_text())
             num_value = float(num_value.replace(',', ''))
-
+            decimals = str(len(str(num_value).split('.')[-1]))
+            fmt = '%.' + decimals + 'f'
+            new_value = locale.format(fmt, float(num_value))
+            new_value = new_value.rstrip("0")
+            if new_value[-1] == '.':
+                new_value = new_value[0:len(new_value)-1]
             convert_value = str(self.convert(num_value, direction))
             decimals = str(len(convert_value.split('.')[-1]))
             fmt = '%.' + decimals + 'f'
@@ -271,9 +276,9 @@ class ConvertActivity(activity.Activity):
             new_convert = new_convert.rstrip("0")
             if new_convert[-1] == '.':
                 new_convert = new_convert[0:len(new_convert)-1]
-            self.change_result(new_convert, direction)
+            self.change_result(new_value, new_convert, direction)
         except ValueError:
-            self.change_result('', direction)
+            self.change_result('', '', direction)
 
     def _update_unit(self, combo, direction):
         if direction == 'from':
@@ -281,7 +286,7 @@ class ConvertActivity(activity.Activity):
         elif direction == 'to':
             self._update_value(self.to_value_entry, direction)
 
-    def change_result(self, new_convert, direction):
+    def change_result(self, new_value, new_convert, direction):
         if direction == 'from':
             self.to_value_entry.handler_block_by_func(self._to_update)
             self.to_value_entry.handler_block_by_func(self._value_insert_text)

--- a/activity.py
+++ b/activity.py
@@ -48,33 +48,37 @@ class ConvertActivity(activity.Activity):
         self._canvas = Gtk.VBox()
 
         self._liststore = Gtk.ListStore(str)
+        arrow_font = Pango.FontDescription('sans bold 18')
+        input_font = Pango.FontDescription('sans 12')
 
         self.combo1 = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()
         self.combo1.pack_start(cell, True)
         self.combo1.set_entry_text_column(0)
         self.combo1.connect('changed', self._from_update)
+        self.combo1.override_font(input_font)
 
         self.from_value_entry = Gtk.Entry()
         self.from_value_entry.set_placeholder_text("Enter source value")
         self.from_value_entry.connect('insert-text', self._value_insert_text)
         self.from_value_entry.connect('changed', self._from_update)
+        self.from_value_entry.override_font(input_font)
 
         self.to_value_entry = Gtk.Entry()
         self.to_value_entry.set_placeholder_text("Enter destination value")
         self.to_value_entry.connect('insert-text', self._value_insert_text)
         self.to_value_entry.connect('changed', self._to_update)
+        self.to_value_entry.override_font(input_font)
 
         self.combo2 = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         cell = Gtk.CellRendererText()
         self.combo2.pack_start(cell, True)
         self.combo2.set_entry_text_column(0)
         self.combo2.connect('changed', self._to_update)
+        self.combo2.override_font(input_font)
 
-
-        input_font = Pango.FontDescription('sans bold 18')
         self.arrow_label = Gtk.Label()
-        self.arrow_label.override_font(input_font)
+        self.arrow_label.override_font(arrow_font)
         self.arrow_label.set_text("→")
 
         l_hbox = Gtk.HBox()

--- a/activity.py
+++ b/activity.py
@@ -64,10 +64,32 @@ class ConvertActivity(activity.Activity):
         self.dic = {}
 
         self._liststore = Gtk.ListStore(str)
+
+        self.label1 = Gtk.Label()
+        self.label1.set_markup('<big>From value</big>')
+        self.label2 = Gtk.Label()
+        self.label2.set_markup('<big>From unit</big>')
+        self.label3 = Gtk.Label()
+        self.label3.set_markup('<big>To value</big>')
+        self.label4 = Gtk.Label()
+        self.label4.set_markup('<big>To unit</big>')
+
+        u_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        u_hbox.pack_start(self.label1, True, True, 5)
+        u_hbox.pack_start(self.label2, True, True, 20)
+        u_hbox.pack_start(self.label3, True, True, 20)
+        u_hbox.pack_start(self.label4, True, True, 5)
+
         arrow_font = Pango.FontDescription(
             '%s %d' % (FONT_FACE, int(FONT_SIZE * 1.8)))
         input_font = Pango.FontDescription(
             '%s %d' % (FONT_FACE, int(FONT_SIZE * 1.2)))
+
+        self.from_value = Gtk.Entry()
+        self.from_value.set_placeholder_text("Enter value")
+        self.from_value.connect('insert-text', self._insert_text_cb)
+        self.from_value.connect('changed', self._from_changed_cb)
+        self.from_value.override_font(input_font)
 
         self.from_unit = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
         self.from_unit.pack_start(Gtk.CellRendererText(), True)
@@ -75,11 +97,9 @@ class ConvertActivity(activity.Activity):
         self.from_unit.connect('changed', self._from_changed_cb)
         self.from_unit.override_font(input_font)
 
-        self.from_value = Gtk.Entry()
-        self.from_value.set_placeholder_text("Enter value")
-        self.from_value.connect('insert-text', self._insert_text_cb)
-        self.from_value.connect('changed', self._from_changed_cb)
-        self.from_value.override_font(input_font)
+        self.arrow = Gtk.Label()
+        self.arrow.override_font(arrow_font)
+        self.arrow.set_text("→")
 
         self.to_value = Gtk.Entry()
         self.to_value.connect('insert-text', self._insert_text_cb)
@@ -92,33 +112,14 @@ class ConvertActivity(activity.Activity):
         self.to_unit.connect('changed', self._to_changed_cb)
         self.to_unit.override_font(input_font)
 
-        self.arrow = Gtk.Label()
-        self.arrow.override_font(arrow_font)
-        self.arrow.set_text("→")
-
-        self.ratio = Ratio()
-
         l_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-        u_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-
-        self.label1 = Gtk.Label()
-        self.label1.set_markup('<big>From value</big>')
-        u_hbox.pack_start(self.label1, True, True, 5)
-        self.label2 = Gtk.Label()
-        self.label2.set_markup('<big>From unit</big>')
-        u_hbox.pack_start(self.label2, True, True, 20)
-        self.label3 = Gtk.Label()
-        self.label3.set_markup('<big>To value</big>')
-        u_hbox.pack_start(self.label3, True, True, 20)
-        self.label4 = Gtk.Label()
-        self.label4.set_markup('<big>To unit</big>')
-        u_hbox.pack_start(self.label4, True, True, 5)
-
         l_hbox.pack_start(self.from_value, True, True, 5)
         l_hbox.pack_start(self.from_unit, True, True, 5)
         l_hbox.pack_start(self.arrow, False, False, 15)
         l_hbox.pack_start(self.to_value, True, True, 5)
         l_hbox.pack_end(self.to_unit, True, True, 5)
+
+        self.ratio = Ratio()
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box.pack_start(u_hbox, False, False, 30)

--- a/activity.py
+++ b/activity.py
@@ -266,7 +266,7 @@ class ConvertActivity(activity.Activity):
 
     def _size_allocate_cb(self, widget, allocation):
         global SCREEN_WIDTH
-        SCREEN_WIDTH = int(allocation.width)
+        SCREEN_WIDTH = allocation.width
 
     def _from_changed_cb(self, widget):
         direction = 'from'

--- a/activity.py
+++ b/activity.py
@@ -97,8 +97,8 @@ class ConvertActivity(activity.Activity):
         l_hbox.pack_start(self.destination_value_entry, True, True, 5)
         l_hbox.pack_end(self.combo2, True, True, 5)
 
-        self._canvas.pack_start(u_hbox, False, False, 20)
-        self._canvas.pack_start(l_hbox, False, False, 5)
+        self._canvas.pack_start(u_hbox, False, False, 30)
+        self._canvas.pack_start(l_hbox, False, False, 0)
 
         self.set_canvas(self._canvas)
 
@@ -240,6 +240,8 @@ class ConvertActivity(activity.Activity):
         if isinstance(widget, Gtk.Entry):
             self._update_value(widget, direction)
         elif isinstance(widget, Gtk.ComboBox):
+            if self.arrow_label.get_text() == '<=':
+                direction = 'destination'
             self._update_unit(widget, direction)
 
     def _destination_update(self, widget):
@@ -247,6 +249,8 @@ class ConvertActivity(activity.Activity):
         if isinstance(widget, Gtk.Entry):
             self._update_value(widget, direction)
         elif isinstance(widget, Gtk.ComboBox):
+            if self.arrow_label.get_text() == '=>':
+                direction = 'source'
             self._update_unit(widget, direction)
 
     def _update_value(self, entry, direction):

--- a/activity.py
+++ b/activity.py
@@ -291,14 +291,14 @@ class ConvertActivity(activity.Activity):
             new_value = locale.format(fmt, float(num_value))
             new_value = new_value.rstrip("0")
             if new_value[-1] == '.':
-                new_value = new_value[0:len(new_value)-1]
+                new_value = new_value[0:len(new_value) - 1]
             convert_value = str(self.convert(num_value, direction))
             decimals = str(len(convert_value.split('.')[-1]))
             fmt = '%.' + decimals + 'f'
             new_convert = locale.format(fmt, float(convert_value))
             new_convert = new_convert.rstrip("0")
             if new_convert[-1] == '.':
-                new_convert = new_convert[0:len(new_convert)-1]
+                new_convert = new_convert[0:len(new_convert) - 1]
             self.change_result(new_value, new_convert, direction)
         except ValueError:
             self.change_result('', '', direction)
@@ -323,7 +323,9 @@ class ConvertActivity(activity.Activity):
             self.label3.set_markup('<big>To value</big>')
             self.label4.set_markup('<big>To unit</big>')
             if new_convert != '' and new_value != '':
-                text = '%s %s ~ %s %s' % (new_value, self._get_active_text(self.from_unit), new_convert, self._get_active_text(self.to_unit))
+                text = '%s %s ~ %s %s' % (
+                    new_value, self._get_active_text(self.from_unit),
+                    new_convert, self._get_active_text(self.to_unit))
                 self.ratio.set_text(text)
             else:
                 self.ratio.set_text('')
@@ -341,10 +343,13 @@ class ConvertActivity(activity.Activity):
             self.label3.set_markup('<big>From value</big>')
             self.label4.set_markup('<big>From unit</big>')
             if new_convert != '' and new_value != '':
-                text = '%s %s ~ %s %s' % (new_convert, self._get_active_text(self.from_unit), new_value, self._get_active_text(self.to_unit))
+                text = '%s %s ~ %s %s' % (
+                    new_convert, self._get_active_text(self.from_unit),
+                    new_value, self._get_active_text(self.to_unit))
                 self.ratio.set_text(text)
             else:
                 self.ratio.set_text('')
+
     def _update_combo(self, data):
         self._liststore.clear()
         self.dic = data

--- a/activity.py
+++ b/activity.py
@@ -70,8 +70,7 @@ class ConvertActivity(activity.Activity):
             '%s %d' % (FONT_FACE, int(FONT_SIZE * 1.2)))
 
         self.from_unit = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
-        cell = Gtk.CellRendererText()
-        self.from_unit.pack_start(cell, True)
+        self.from_unit.pack_start(Gtk.CellRendererText(), True)
         self.from_unit.set_entry_text_column(0)
         self.from_unit.connect('changed', self._from_changed_cb)
         self.from_unit.override_font(input_font)
@@ -88,8 +87,7 @@ class ConvertActivity(activity.Activity):
         self.to_value.override_font(input_font)
 
         self.to_unit = Gtk.ComboBox.new_with_model_and_entry(self._liststore)
-        cell = Gtk.CellRendererText()
-        self.to_unit.pack_start(cell, True)
+        self.to_unit.pack_start(Gtk.CellRendererText(), True)
         self.to_unit.set_entry_text_column(0)
         self.to_unit.connect('changed', self._to_changed_cb)
         self.to_unit.override_font(input_font)


### PR DESCRIPTION
Fixes #25 

**Issue**
1) The decimal point is not being inserted in the source or destination entry boxes
2) The entry widgets and combo box can be enlarged
3) The following warnings are thrown on running the activity

```
/usr/local/lib/python2.7/dist-packages/sugar3/activity/activity.py:472: Warning: g_value_get_int: assertion 'G_VALUE_HOLDS_INT (value)' failed
  Gtk.main()
/home/buba/sugar-stuff/sugar-activities/convert/activity.py:275: Warning: g_value_get_int: assertion 'G_VALUE_HOLDS_INT (value)' failed
  self.source_value_entry.set_text(new_convert)
/home/buba/sugar-stuff/sugar-activities/convert/activity.py:267: Warning: g_value_get_int: assertion 'G_VALUE_HOLDS_INT (value)' failed
  self.destination_value_entry.set_text(new_convert)
```

Kindly guide me on the issues I have mentioned above.

Tested on Ubuntu 18.04 and Sugar v0.114